### PR TITLE
Simplify AuthWidgetProvider: dont need to return an empty MultiProvider

### DIFF
--- a/packages/auth_widget_builder/lib/auth_widget_builder.dart
+++ b/packages/auth_widget_builder/lib/auth_widget_builder.dart
@@ -26,15 +26,13 @@ class AuthWidgetBuilder extends StatelessWidget {
       stream: authService.authStateChanges(),
       builder: (context, snapshot) {
         final AppUser user = snapshot.data;
-        if (user != null) {
-          return MultiProvider(
-            providers: userProvidersBuilder != null
-                ? userProvidersBuilder(context, user)
-                : [],
-            child: builder(context, snapshot),
-          );
+        if (user == null || userProvidersBuilder == null) {
+          return builder(context, snapshot);
         }
-        return builder(context, snapshot);
+        return MultiProvider(
+          providers: userProvidersBuilder(context, user),
+          child: builder(context, snapshot),
+        );
       },
     );
   }


### PR DESCRIPTION
I think you could simplify AuthWidgetProvider to this, since you don't need to return an empty Multiprovider, and i find it nicer to return early on fails. Have NOT tested this though, and i don't have much experience with Multiprovider.